### PR TITLE
load locale by name and native name

### DIFF
--- a/t/11load-name.t
+++ b/t/11load-name.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More 0.96;
+
+use DateTime::Locale;
+
+my $builder = Test::More->builder;
+## no critic (InputOutput::RequireCheckedSyscalls)
+binmode $builder->output,         ':encoding(UTF-8)';
+binmode $builder->failure_output, ':encoding(UTF-8)';
+binmode $builder->todo_output,    ':encoding(UTF-8)';
+
+## use critic
+
+for my $code (qw( English French Italian Latvian latviešu )) {
+    ok(
+        DateTime::Locale->load($code),
+        "code $code loaded a locale"
+    );
+}
+
+done_testing();

--- a/tools/lib/ModuleGenerator.pm
+++ b/tools/lib/ModuleGenerator.pm
@@ -123,8 +123,8 @@ sub _write_data_pm ($self) {
     my %raw_locales;
     for my $locale ( $self->_locales->@* ) {
         $codes{ $locale->code }               = 1;
-        $names{ $locale->en_name }            = 1;
-        $native_names{ $locale->native_name } = 1;
+        $names{ $locale->en_name }            = $locale->code;
+        $native_names{ $locale->native_name } = $locale->code;
         $raw_locales{ $locale->code }         = $locale->data_hash;
     }
 


### PR DESCRIPTION
Hi

According to the doc, DateTime::Locale->load($code) should be able to load by name: "The name provided may be either the English or native name.", but it doesn't.