### PR TITLE
Support custom locales with new register_data_locale function

### DIFF
--- a/lib/DateTime/Locale.pm
+++ b/lib/DateTime/Locale.pm
@@ -478,8 +478,8 @@ names use UTF-8 as appropriate.
 =head2 DateTime::Locale->register_from_data( $locale_data )
 
 This method allows you to register a custom locale.  The data for the locale
-is specified as a hash, and should use keys matching the method names given 
-in C<DateTime::Locale::FromData>.  The one exception is that the locale 
+is specified as a hash, and should use keys matching the method names given
+in C<DateTime::Locale::FromData>.  The one exception is that the locale
 C<code> should be specified under the key C<id>.
 
 Example of making a custom locale based off of C<en-US>:
@@ -488,9 +488,9 @@ Example of making a custom locale based off of C<en-US>:
   my %data = %$locale;                          #copy the contents
   $data{id} = 'en-US-CUSTOM';
   $data{time_format_medium} =   'HH:mm:ss';     #use 24 hour time
-  
+
   DateTime::Locale->register_data_locale(%data);
-  
+
   say DateTime->now(locale => 'en-US-CUSTOM')->strftime('%X');
   #18:24:38
   say DateTime->now(locale => 'en-US')->strftime('%X');

--- a/lib/DateTime/Locale.pm
+++ b/lib/DateTime/Locale.pm
@@ -72,31 +72,18 @@ sub _register {
 }
 
 sub register_data_locale {
-    my $class = shift;
-
-    %LoadCache = ();
-
-    if ( ref $_[0] ) {
-        return $class->_register_data_locale( %{ $_[0] } );
-    }
-    else {
-        return $class->_register_data_locale(@_);
-    }
-}
-
-sub _register_data_locale {
     shift;
     my %p = @_;
 
-    my $id = $p{id};
+    my $code = $p{code};
 
-    die q{'\@' or '=' are not allowed in locale ids}
-        if $id =~ /[\@=]/;
+    die q{'\@' or '=' are not allowed in locale codes}
+        if $code =~ /[\@=]/;
 
-    $id =~ s/_/-/g;
+    $code =~ s/_/-/g;
 
-    DateTime::Locale::Data::add_locale( $id, \%p );
-    return $LoadCache{$id} = DateTime::Locale::FromData->new( \%p );
+    DateTime::Locale::Data::add_locale( $code, \%p );
+    return $LoadCache{$code} = DateTime::Locale::FromData->new( \%p );
 }
 
 sub add_aliases {
@@ -445,8 +432,7 @@ Eg. For the locale code C<es-Latn-XX> the fallback search would be:
 If no suitable replacement is found, then an exception is thrown.
 
 The loaded locale is cached, so that B<locale objects may be
-singletons>. Calling C<< DateTime::Locale->register() >>,
-C<< DateTime::Locale->register_data_locale() >>, C<<
+singletons>. Calling C<< DateTime::Locale->register() >>, C<<
 DateTime::Locale->add_aliases() >>, or C<< DateTime::Locale->remove_alias() >>
 clears the cache.
 
@@ -479,17 +465,16 @@ names use UTF-8 as appropriate.
 
 This method allows you to register a custom locale.  The data for the locale
 is specified as a hash, and should use keys matching the method names given
-in C<DateTime::Locale::FromData>.  The one exception is that the locale
-C<code> should be specified under the key C<id>.
+in C<DateTime::Locale::FromData>.
 
 Example of making a custom locale based off of C<en-US>:
 
   my $locale = DateTime::Locale->load('en-US');
-  my %data = %$locale;                          #copy the contents
-  $data{id} = 'en-US-CUSTOM';
-  $data{time_format_medium} =   'HH:mm:ss';     #use 24 hour time
+  my $data = $locale->locale_cldr_data();         #retrieve the raw locale data
+  $data->{code} = 'en-US-CUSTOM';
+  $data->{time_format_medium} =   'HH:mm:ss';     #use 24 hour time
 
-  DateTime::Locale->register_data_locale(%data);
+  DateTime::Locale->register_data_locale(%$data);
 
   say DateTime->now(locale => 'en-US-CUSTOM')->strftime('%X');
   #18:24:38

--- a/lib/DateTime/Locale.pm
+++ b/lib/DateTime/Locale.pm
@@ -71,6 +71,34 @@ sub _register {
     $Class{$id} = $p{class} if defined exists $p{class};
 }
 
+sub register_data_locale {
+    my $class = shift;
+
+    %LoadCache = ();
+
+    if ( ref $_[0] ) {
+        return $class->_register_data_locale( %{ $_[0] } );
+    }
+    else {
+        return $class->_register_data_locale(@_);
+    }
+}
+
+sub _register_data_locale {
+    shift;
+    my %p = @_;
+
+    my $id = $p{id};
+
+    die q{'\@' or '=' are not allowed in locale ids}
+        if $id =~ /[\@=]/;
+
+    $id =~ s/_/-/g;
+
+    DateTime::Locale::Data::add_locale( $id, \%p );
+    return $LoadCache{$id} = DateTime::Locale::FromData->new( \%p );
+}
+
 sub add_aliases {
     shift;
 
@@ -417,7 +445,8 @@ Eg. For the locale code C<es-Latn-XX> the fallback search would be:
 If no suitable replacement is found, then an exception is thrown.
 
 The loaded locale is cached, so that B<locale objects may be
-singletons>. Calling C<< DateTime::Locale->register() >>, C<<
+singletons>. Calling C<< DateTime::Locale->register() >>,
+C<< DateTime::Locale->register_data_locale() >>, C<<
 DateTime::Locale->add_aliases() >>, or C<< DateTime::Locale->remove_alias() >>
 clears the cache.
 
@@ -445,6 +474,27 @@ reference if called in a scalar context.
 Returns an unsorted list of the available locale names in their native
 language, or an array reference if called in a scalar context. All native
 names use UTF-8 as appropriate.
+
+=head2 DateTime::Locale->register_from_data( $locale_data )
+
+This method allows you to register a custom locale.  The data for the locale
+is specified as a hash, and should use keys matching the method names given
+in C<DateTime::Locale::FromData>.  The one exception is that the locale
+C<code> should be specified under the key C<id>.
+
+Example of making a custom locale based off of C<en-US>:
+
+  my $locale = DateTime::Locale->load('en-US');
+  my %data = %$locale;                          #copy the contents
+  $data{id} = 'en-US-CUSTOM';
+  $data{time_format_medium} =   'HH:mm:ss';     #use 24 hour time
+
+  DateTime::Locale->register_data_locale(%data);
+
+  say DateTime->now(locale => 'en-US-CUSTOM')->strftime('%X');
+  #18:24:38
+  say DateTime->now(locale => 'en-US')->strftime('%X');
+  # 6:24:38 PM
 
 =head1 LOADING LOCALES IN A PRE-FORKING SYSTEM
 

--- a/lib/DateTime/Locale/Data.pm
+++ b/lib/DateTime/Locale/Data.pm
@@ -5891,8 +5891,18 @@ sub add_locale {
     my $code = shift;
     my $data = shift;
 
-    $Codes{$code} = 1;
-    $Names{ $data->{en_language} } = $code if exists $data->{en_language};
+    die "You cannot add an existing locale ('$code')\n"
+        if exists $Codes{$code};
+    die
+        "'en_language' or 'language' required in data hash to add new locale\n"
+        if !( exists $data->{en_language} || exists $data->{language} );
+
+    my $lang
+        = ( exists $data->{en_language} )
+        ? $data->{en_language}
+        : $data->{language};
+    $Names{$lang}                            = $code;
+    $Codes{$code}                            = 1;
     $NativeNames{ $data->{native_language} } = $code
         if exists $data->{native_language};
     $LocaleData{$code} = $data;

--- a/lib/DateTime/Locale/Data.pm
+++ b/lib/DateTime/Locale/Data.pm
@@ -5888,6 +5888,16 @@ sub _data_for {
     return $data;
 }
 
+sub add_locale {
+    my $code = shift;
+    my $data = shift;
+
+    $Codes{$code} = 1;
+    $Names{$data->{en_language}} = $code if exists $data->{en_language};
+    $NativeNames{$data->{native_language}} = $code if exists $data->{native_language};
+    $LocaleData{$code} = $data;
+}
+
 # ABSTRACT: Locale data generated from CLDR
 
 __END__

--- a/lib/DateTime/Locale/Data.pm
+++ b/lib/DateTime/Locale/Data.pm
@@ -5888,6 +5888,17 @@ sub _data_for {
     return $data;
 }
 
+sub add_locale {
+    my $code = shift;
+    my $data = shift;
+
+    $Codes{$code} = 1;
+    $Names{ $data->{en_language} } = $code if exists $data->{en_language};
+    $NativeNames{ $data->{native_language} } = $code
+        if exists $data->{native_language};
+    $LocaleData{$code} = $data;
+}
+
 # ABSTRACT: Locale data generated from CLDR
 
 __END__

--- a/lib/DateTime/Locale/FromData.pm
+++ b/lib/DateTime/Locale/FromData.pm
@@ -64,6 +64,7 @@ BEGIN {
         glibc_date_1_format
         glibc_time_format
         glibc_time_12_format
+        locale_cldr_data
     );
 
     for my $meth (@methods) {
@@ -101,6 +102,7 @@ sub new {
         %{$data},
         default_date_format_length => 'medium',
         default_time_format_length => 'medium',
+        locale_cldr_data           => $data
     }, $class;
 }
 
@@ -483,5 +485,10 @@ week, with Monday being 1 and Sunday being 7.
 =item * $locale->version
 
 The CLDR version from which this locale was generated.
+
+=item * $locale->locale_cldr_data
+
+The original data used to create this locale, which can be used to customize
+locales via C<DateTime::Locale::register_data_locale>
 
 =back

--- a/t/12register_date_locale.t
+++ b/t/12register_date_locale.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use DateTime::Locale;
+
+{
+    my $base_locale = DateTime::Locale->load('en-US');
+    my $data        = $base_locale->locale_cldr_data();
+    $data->{code} = 'en-US-CUSTOM';
+
+    DateTime::Locale->register_data_locale(%$data);
+    my $l = DateTime::Locale->load('en-US-CUSTOM');
+
+    isa_ok( $l, 'DateTime::Locale::FromData' );
+    ok( $l, 'was able to load en_US_CUSTOM' );
+    is( $l->code(), 'en-US-CUSTOM', 'code is set properly' );
+
+}
+
+done_testing();


### PR DESCRIPTION
Recent versions of DateTime::Locale no longer support subclassing
the DateTime::Locale::<locale> classes, as they do not exist.  The new
plan is to have users get a locale they want to modify from
DateTime::Locale->load, or create one from scratch, then they can
register it using the register_data_locale function.

Resolves https://github.com/houseabsolute/DateTime-Locale/issues/19