### PR TITLE
Handle a local which does not define a native name for its own language

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 {{$NEXT}}
 
+- Fix handling of a locale (nds) that does not provide a native name for its
+  own locale code. This is a bug in CLDR, but since it exists we should handle
+  it sanely.
+
+
 1.18     2018-04-03
 
 - Rebuilt all locale data with CLDR 33, released on 2018-03-26.

--- a/lib/DateTime/Locale/Data.pm
+++ b/lib/DateTime/Locale/Data.pm
@@ -1515,7 +1515,6 @@ our %Names = (
 #<<<
 ### :start NativeNames:
 our %NativeNames = (
-  "" => "nds",
   Afrikaans => "af",
   "Afrikaans Namibi\N{U+00eb}" => "af-NA",
   "Afrikaans Suid-Afrika" => "af-ZA",

--- a/tools/lib/ModuleGenerator.pm
+++ b/tools/lib/ModuleGenerator.pm
@@ -142,10 +142,15 @@ sub _write_data_pm ($self) {
     my %native_names;
     my %raw_locales;
     for my $locale ( $self->_locales->@* ) {
-        $codes{ $locale->code }               = 1;
-        $names{ $locale->en_name }            = $locale->code;
-        $native_names{ $locale->native_name } = $locale->code;
-        $raw_locales{ $locale->code }         = $locale->data_hash;
+        $codes{ $locale->code }    = 1;
+        $names{ $locale->en_name } = $locale->code;
+
+        # As of CLDR 33.0.0 the nds locale does not specify a native name for
+        # itself (wtf).
+        if ( $locale->native_name ) {
+            $native_names{ $locale->native_name } = $locale->code;
+        }
+        $raw_locales{ $locale->code } = $locale->data_hash;
     }
 
     my $data_pm_file = path(qw( lib DateTime Locale Data.pm ));


### PR DESCRIPTION
The nds locale seems buggy, but if we don't handle this we end up with a
%NativeNames key of "" for this locale, which is not good.