### PR TITLE
support loading locale data from directories relative to the current working dir in @INC

### DIFF
--- a/lib/DateTime/Locale/Data.pm
+++ b/lib/DateTime/Locale/Data.pm
@@ -19,6 +19,7 @@ use warnings;
 use namespace::autoclean;
 
 use File::ShareDir qw( dist_file );
+use File::Spec;
 
 our $VERSION = '1.27';
 
@@ -6090,7 +6091,10 @@ sub locale_data {
 sub _data_for {
     my $code = shift;
 
-    my $data = do( dist_file( 'DateTime-Locale', $code . '.pl' ) );
+    my $data
+        = do(
+        File::Spec->rel2abs( dist_file( 'DateTime-Locale', $code . '.pl' ) )
+        );
     die $@ if $@;
 
     return $data;

--- a/t/13load-from-relative-inc-path.t
+++ b/t/13load-from-relative-inc-path.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::File::ShareDir::Dist { 'DateTime-Locale' => 'share' };
+
+use File::ShareDir qw( dist_dir );
+use File::Spec;
+
+use DateTime::Locale;
+
+{
+
+    my $dist_dir            = dist_dir('DateTime-Locale');
+    my @dist_dir_components = File::Spec->splitdir($dist_dir);
+
+    pop @dist_dir_components for 0 .. 3; # pop auto/share/dist/DateTime-Locale
+    my $share_dir = pop @dist_dir_components;
+
+    chdir File::Spec->catdir(@dist_dir_components)
+        or die 'couldn\'t change to tmp directory';
+
+    local @INC = ($share_dir);
+    my $l = DateTime::Locale->load('de-DE');
+
+    ok( $l, 'was able to load de-DE locale from relative dir' );
+    isa_ok( $l, 'DateTime::Locale::FromData' );
+}
+
+done_testing();


### PR DESCRIPTION
This commit adds support for loading locale data from directories relative to the current working dir in `@INC` whithout the current working dir itself beein in `@INC`.

With an `@INC` like this:

```
@INC = (
          'libs/carton/local/lib/perl5', # contains `auto/share/dist/DateTime-Locale/`
          '/usr/share/perl5',
        );
```

The call to `dist_file( 'DateTime-Locale', $code . '.pl' )` will return `libs/carton/local/lib/perl5/auto/share/dist/DateTime-Locale/$code.pl`. This beeing a relative path, `do` will search for it in the `@INC` directories and return `undef` as it will not be able to find it. We can instead use `File::Spec->rel2abs` to resolve the path from the current working directory and hand the absolute path to `do` which will then load it directly from the specified path.

Do you see any problems with this approach?
