### PR TITLE
10 locale objects return references to internal structures not copies

### DIFF
--- a/lib/DateTime/Locale/FromData.pm
+++ b/lib/DateTime/Locale/FromData.pm
@@ -7,6 +7,7 @@ use namespace::autoclean;
 use DateTime::Locale::Util qw( parse_locale_code );
 use Params::ValidationCompiler 0.13 qw( validation_for );
 use Specio::Declare;
+use Storable qw(dclone);
 
 our $VERSION = '1.27';
 
@@ -247,7 +248,7 @@ sub variant_id {
 }
 
 sub locale_data {
-    return %{ $_[0]->{locale_data} };
+    return %{ dclone( $_[0]->{locale_data} ) };
 }
 
 sub STORABLE_freeze {
@@ -485,8 +486,8 @@ week, with Monday being 1 and Sunday being 7.
 
 =head2 $locale->locale_data
 
-Returns the original data used to create this locale as a hash. This is here
-to facilitate creating custom locales via
+Returns a clone of the original data used to create this locale as a hash.
+This is here to facilitate creating custom locales via
 C<DateTime::Locale->register_data_locale>.
 
 =cut

--- a/lib/DateTime/Locale/FromData.pm
+++ b/lib/DateTime/Locale/FromData.pm
@@ -392,7 +392,9 @@ string.
 
 =head2 $locale->era_narrow
 
-These methods all return an array reference containing the specified data.
+These methods all return an array reference containing the specified data. If
+you want to modify the data you should create a copy of the referenced data
+first to prevent your changes from affecting the original locale data.
 
 The methods with "format" in the name should return strings that can be used a
 part of a string, like "the month of July". The stand alone values are for use

--- a/t/14locale-data-is-cloned.t
+++ b/t/14locale-data-is-cloned.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::File::ShareDir::Dist { 'DateTime-Locale' => 'share' };
+
+use Storable qw(dclone);
+
+use DateTime::Locale;
+
+{
+    my $cldr            = DateTime::Locale->load('en');
+    my %locale_data     = $cldr->locale_data;
+    my $locale_data_old = dclone( \%locale_data );
+    delete $locale_data{available_formats}{d};
+    my $locale_data_new = { $cldr->locale_data };
+
+    is_deeply(
+        $locale_data_old, $locale_data_new,
+        'modifying locale_data doesn\'t affect original locale'
+    );
+}
+
+done_testing();


### PR DESCRIPTION
This addresses https://github.com/houseabsolute/DateTime-Locale/issues/10

I figured I'll give this a try.

This should solve the described issue. I didn't find any other places where we leak internal structures to the outside without creating a copy.

In line 76: If I am not mistaken it would suffice to check if we have an `ARRAY` ref here and create a shallow clone of the array. I went for the `dclone` solution for increased safety/compatibility 