### PR TITLE
Accepted tainted args

### DIFF
--- a/lib/DateTime/Locale/Data.pm
+++ b/lib/DateTime/Locale/Data.pm
@@ -6143,9 +6143,12 @@ sub locale_data {
 sub _data_for {
     my $code = shift;
 
+    # Basic sanity check before we load from disk.
+    die "Invalid locale code - $code\n" if $code !~ /^([A-Za-z0-9-]+)$/;
+
     my $data
         = do(
-        File::Spec->rel2abs( dist_file( 'DateTime-Locale', $code . '.pl' ) )
+        File::Spec->rel2abs( dist_file( 'DateTime-Locale', $1 . '.pl' ) )
         );
     die $@ if $@;
     die $! if $!;

--- a/t/taint.t
+++ b/t/taint.t
@@ -1,0 +1,17 @@
+#!perl -T
+
+use Scalar::Util 'tainted';
+use Test2::V0 -target => 'DateTime::Locale';
+
+skip_all 'Taint not supported' unless ${^TAINT};
+
+# Concat code with zero bytes of executable name in order to taint it.
+my $code = 'en-GB' . substr $^X, 0, 0;
+
+ok tainted $code, 'code is tainted';
+
+try_ok {
+    is CLASS->load($code)->code, $code, 'code is correct';
+} 'tainted load lives';
+
+done_testing;


### PR DESCRIPTION
At $work we're in the process of upgrading Debian LTS (Stretch → Bullseye). This has caused some fallout in loading locales using tainted variables. This appears to be unintended fallout from the 1.11 change where locales are now read from disk on-demand.

Stretch:
```
$ perl -MDateTime::Locale -TE 'say DateTime::Locale->VERSION; say DateTime::Locale->load(@ARGV)' en-GB
1.11
DateTime::Locale::FromData=HASH(0x563886777b70)
```

Bullseye:
```
$ perl -MDateTime::Locale -TE 'say DateTime::Locale->VERSION; say DateTime::Locale->load(@ARGV)' en-GB
1.31
Insecure dependency in do while running with -T switch at /usr/share/perl5/DateTime/Locale/Data.pm line 6086.
```

Assuming the change was unintentional this commit restores the old behaviour while keeping the data on disk. I don't think it's unreasonable that a locale code would be tainted if it came from the database of the web request.

The commit does a little validation but to be honest it's probably overkill as the value is checked higher up the stack, so we could easily make the regex `/(.+)/` if you prefer.

The test should be skipping itself on perls compiled without taint support.