### PR TITLE
Corrected method prefers_24_hour_time

### DIFF
--- a/lib/DateTime/Locale/FromData.pm
+++ b/lib/DateTime/Locale/FromData.pm
@@ -200,7 +200,9 @@ sub prefers_24_hour_time {
     return $self->{prefers_24_hour_time}
         if exists $self->{prefers_24_hour_time};
 
-    $self->{prefers_24_hour_time} = $self->time_format_short =~ /h|K/ ? 0 : 1;
+    my $pat = $self->time_format_short;
+    my @parts = split( /(?:'(?:(?:[^']|'')*)')/, $pat );
+    $self->{prefers_24_hour_time} = scalar( grep( /h|K/, @parts ) ) ? 0 : 1;
 }
 
 sub language_code {


### PR DESCRIPTION
The method `prefers_24_hour_time` in module `DateTime::Locale::FromData` is susceptible of catching literals embedded in pattern, such as it would be the case for the locale `fr-CA` whose time short pattern is `HH 'h' mm`.

With the current method, and its simple check, it would conclude `fr-CA` is a 12-hours locale whereas it is a 24-hours locale. This is also true for the locale `hsb` (`H:mm 'hodź'.`), `nds` (`'Kl'. H.mm`) or the locale `oc` (`H'h'mm`)

Instead, I recommend the proposed change in the pull request.